### PR TITLE
Save parsed cookies to socket.request.cookies and leave headers untouched

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ io.use(cookieParser);
 
 // use cookies from some middleware
 io.use(function (socket, next) {
-  console.log(socket.request.headers.cookie.someCookie);
+  console.log(socket.request.cookies.someCookie);
 });
 
 // you can use parsed cookies on your namespaces also
 io.of('/namespace').use(function (socket, next) {
-  console.log(socket.request.headers.cookie.someCookie);
+  console.log(socket.request.cookies.someCookie);
 });
 ```
 

--- a/lib/socket.io-cookie.js
+++ b/lib/socket.io-cookie.js
@@ -4,7 +4,7 @@ var cookie = require('cookie');
 
 module.exports = function (socket, next) {
 	if (socket.request.headers.cookie) {
-		socket.request.headers.cookie = cookie.parse(socket.request.headers.cookie);
+		socket.request.cookies = cookie.parse(socket.request.headers.cookie);
 	}
 
   next();


### PR DESCRIPTION
At the moment this module overrides headers and you can not read the raw cookie header once the cookie header is parsed. Cookie parser for Express (`cookie-parser`) attaches cookies on the request object and leaves headers untouched.

Please accept this PR which fixes the problem described above by storing cookies to `socket.request.cookies` instead of overriding the header.
